### PR TITLE
Removed explicit loglevel.

### DIFF
--- a/src/Ioka.Services.Demo/Startup.cs
+++ b/src/Ioka.Services.Demo/Startup.cs
@@ -54,7 +54,7 @@ namespace Ioka.Services.Demo
 
             services
                 .AddIokaVersionProvider(new VersionProvider())
-                .AddIokaLogging(config, Foundation.Logging.LogLevel.Debug, () => "test")
+                .AddIokaLogging(config, () => "test")
                 .AddMvc()
                 .AddIokaFormatters()
                 .SetCompatibilityVersion(CompatibilityVersion.Version_2_2);

--- a/src/Ioka.Services.Foundation/Ioka.Services.Foundation.csproj
+++ b/src/Ioka.Services.Foundation/Ioka.Services.Foundation.csproj
@@ -8,13 +8,13 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.HttpOverrides" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="5.3.0" />
-    <PackageReference Include="Serilog" Version="2.8.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
+    <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="4.0.1" />

--- a/src/Ioka.Services.Foundation/Logging/LoggingExtensions.cs
+++ b/src/Ioka.Services.Foundation/Logging/LoggingExtensions.cs
@@ -1,8 +1,8 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Serilog;
 using Serilog.Core;
 using Serilog.Events;
-using Serilog.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -20,7 +20,7 @@ namespace Ioka.Services.Foundation.Logging
         /// <param name="createIndexName">Function to create index name per request.</param>
         /// <param name="enrichers">Leave null to accept default enricher.</param>
         /// <returns></returns>
-        public static IServiceCollection AddIokaLogging(this IServiceCollection services, ElasticConfig config, LogLevel level,
+        public static IServiceCollection AddIokaLogging(this IServiceCollection services, ElasticConfig config,
             Func<string> createIndexName, ILogEventEnricher[] enrichers = null, ILogEventSink failureSink = null, Action<LogEvent> failureCallback = null)
         {
             services.AddHttpContextAccessor();
@@ -28,29 +28,12 @@ namespace Ioka.Services.Foundation.Logging
             services.AddSingleton<LogEnricher>((serviceProvider) => new LogEnricher(new LogContext(),
                 LogContextFactory.CreateFactory(serviceProvider.GetService<ContextProvider>())));
 
-            services.AddScoped<ILog>((serviceProvider) => new Log(config, level, createIndexName, failureSink, failureCallback, 
+            services.AddScoped<ILog>((serviceProvider) => new Log(config, createIndexName, failureSink, failureCallback, 
                 (null == enrichers ? new[] { serviceProvider.GetService<LogEnricher>() } : enrichers)));
 
             var svcProvider = services.BuildServiceProvider();
             var log = svcProvider.GetService<ILog>();
-            services.AddLogging(loggingBuilder =>
-            {
-                // This is a variation of the .AddSerilog extension which filters out noisy framework messages.
-                loggingBuilder.AddProvider((ILoggerProvider)new SerilogLoggerProvider(log.Logger, false));
-                FilterLoggingBuilderExtensions.AddFilter<SerilogLoggerProvider>(loggingBuilder, (category, logLevel) =>
-                {
-                    // Log all application level events from ALog.AspNet.Core.DefaultLogSource
-                    if (category == "Ioka.Services.Foundation.Logging.DefaultLogSource") return true;
-                    // Log only Error level or above for other sources otherwise the logs will get jammed with 
-                    // every ASP.NET Core event logged to ILogger this could be modified to allow configurable 
-                    // logging of all framework events most of which are at Information level.
-                    if (logLevel > Microsoft.Extensions.Logging.LogLevel.Warning)
-                    {
-                        return true;
-                    }
-                    return false;
-                });
-            });
+            services.AddLogging(configure => configure.AddSerilog(log.Logger, dispose: true));
 
             // Configure ASP.NET Core extensions ILogger for default out of the box behavior.
             services.AddSingleton<Microsoft.Extensions.Logging.ILogger>((x) => x.GetRequiredService<ILogger<DefaultLogSource>>());


### PR DESCRIPTION
Use default config level.

"Logging": {
    "LogLevel": {
      "Default": "Information", // Error | Warning | Information | Debug
      "System": "Warning",
      "Microsoft": "Warning"
    },